### PR TITLE
Linking fix

### DIFF
--- a/server/database.py
+++ b/server/database.py
@@ -398,7 +398,11 @@ class FieldsTableOps:
                 self.db_ops.close_connection(conn)
                 return False
             else:
+                count = c.execute("SELECT * FROM Fields")
+                total = len(count.fetchall())
                 self.db_ops.close_connection(conn)
+                if total == 0:
+                    return False
                 return True
         return False
 

--- a/server/database.py
+++ b/server/database.py
@@ -3,7 +3,7 @@ import sqlite3
 from sqlite3 import Error
 from datetime import timezone
 from datetime import datetime
-from sync import sync_one_item
+import sync
 import os
 import logging
 import functions
@@ -549,7 +549,7 @@ def link_items(jira_item, jama_item, jira_fields, jama_fields, num_fields, sessi
     # remove the linked items and the fields from database.
     sync_success = True
     try:
-        sync_success = sync.sync_one_item(jira_item[id_], session)
+        sync_success = sync.sync_one_item(jira_item[id_], session, linking=True)
     except:
         logging.exception(f"Something went wrong when trying to do initial sync on items {jira_item[id_]}, {jama_item[id_]}")
         sync_success = False
@@ -669,8 +669,8 @@ def logging_demo():
     #db_ops.rename_column(items_table, "Project", "LastSyncTime")
 
     # Demo delete table. ***USE WITH CAUTION***
-    # # # # db_ops.delete_table("Fields")
-    # # # # db_ops.delete_table("Items")
+    # db_ops.delete_table("Fields")
+    # db_ops.delete_table("Items")
     # # # db_ops.delete_table("SyncInformation")
     # Demo add column to existing table.
     #db_ops.add_column(items_table, "LastSyncTime", f"DATETIME {datetime.now(timezone.utc).strftime('%Y-%m-%dT%H:%M:%S.%f%z')}")
@@ -728,5 +728,4 @@ def logging_demo():
     print("Field(s) ready for syncing:", fields_table_ops.get_fields_to_sync(items_table_ops, sync_table_ops)[1])
 
     #demo_sync_methods(db_path)
-    #logging_demo()
-    '''
+    #logging_demo()'''

--- a/server/routes.py
+++ b/server/routes.py
@@ -468,6 +468,7 @@ def get_logs():
 # Links two items. Accepts 4 arrays: jama_item, jira_item, jama_fields, and jira_fields, and 1
 # integer parameter which indicates the total number of fields in each fields array.
 @app.route('/link_items', methods=['POST'])
+@jwt_required
 def link_item():
     try:
         token = get_jwt_identity()
@@ -497,7 +498,7 @@ def link_item():
         num_jama_fields = len(jama_fields)
         if num_jira_fields != num_jama_fields:
             return {"error": "The number of Jama fields to link does not match the number of Jira fields."}, 500
-        success = database.link_items(jira_item, jama_item, jira_fields, jama_fields, num_jama_fields, session)
+        success = link_items(jira_item, jama_item, jira_fields, jama_fields, num_jama_fields, session)
         if success == False:
             return {"error": "Linking unsuccessful"}, 500
 

--- a/server/set_up_log.py
+++ b/server/set_up_log.py
@@ -1,15 +1,10 @@
 import logging
 from pythonjsonlogger import jsonlogger
 
-def log_setup(level = logging.INFO):
-    root_logger= logging.getLogger()
-    root_logger.setLevel(level)
-    handler = logging.FileHandler('error.log', 'a', 'utf-8')
-    handler.setFormatter(logging.Formatter('%(asctime)s %(levelname)s %(name)s %(message)s', datefmt='%m/%d/%Y %I:%M:%S %p'))
-    root_logger.addHandler(handler)
-
-def json_log_setup(level = logging.DEBUG):
+def json_log_setup(level = logging.INFO):
     logger = logging.getLogger()
+    if logger.hasHandlers():
+        logger.handlers.clear()
     logger.setLevel(level)
     logHandler = logging.FileHandler('error_json.log', 'a', 'utf-8')
     formatter = jsonlogger.JsonFormatter('%(asctime)s %(levelname)s %(name)s %(message)s', datefmt='%m/%d/%Y %I:%M:%S %p')

--- a/server/sync.py
+++ b/server/sync.py
@@ -21,7 +21,7 @@ def last_sync_period():
 
 #are we making our own item_id for internal tracking? or should we just
 #use the jama or jira item id and specify that?
-def sync_one_item(item_id, session):
+def sync_one_item(item_id, session, linking = False):
 
     #session = connection()
     #session.initiate_jama(os.environ["JAMA_SYNC_ORG"], os.environ["JAMA_SYNC_USERNAME"], os.environ["JAMA_SYNC_PASSWORD"])
@@ -51,7 +51,7 @@ def sync_one_item(item_id, session):
     last_sync = datetime.strptime(last_sync, '%Y-%m-%dT%H:%M:%S.%f%z')
     pos, src_id, dst_id, most_recent_change = session.most_recent_update(sync_item1[3],sync_item1[0], sync_item2[3], sync_item2[0])
     
-    if most_recent_change <= last_sync:
+    if most_recent_change <= last_sync and linking == False:
         # the last sync time was the same or newer than the last modified time
         return False
 
@@ -135,7 +135,7 @@ def admin_sync():
     session = connection()
     session.initiate_jama(os.environ["JAMA_SYNC_ORG"], os.environ["JAMA_SYNC_USERNAME"], os.environ["JAMA_SYNC_PASSWORD"])
     session.initiate_jira(os.environ["JIRA_SYNC_ORG"], os.environ["JIRA_SYNC_USERNAME"], os.environ["JIRA_SYNC_PASSWORD"])
-    db_path = os.path.join(os.path.dirname(os.getcwd()), "C2TB/JamaJiraConnectDataBase.db")
+    db_path = os.path.join(os.path.dirname(os.getcwd()), path_to_db)
     items_table = database.ItemsTableOps(db_path)
     success = True
     linked_items = items_table.get_linked_items()

--- a/server/sync.py
+++ b/server/sync.py
@@ -97,19 +97,23 @@ def sync_one_item(item_id, session):
         if(type(dst_data_i) == str):
             src_data_i = str(src_data_i)
         dst_field_values[dst_field_names[i]] = src_data_i
-
+    success = True
     #send the data
     if src_item[3] == "jama" or src_item[3] == "Jama":
-        session.set_jira_item(dst_field[1], dst_field_values)
+        curr_success = session.set_jira_item(dst_field[1], dst_field_values)
+        if curr_success == False:
+            success = False
     else:
-        session.set_jama_item(dst_field[1], dst_field_values)
+        curr_success = session.set_jama_item(dst_field[1], dst_field_values)
+        if curr_success == False:
+            success = False
 
     #update the last sync time with the current time. 
     sync_end_time = datetime.now(timezone.utc).strftime('%Y-%m-%dT%H:%M:%S.%f%z')
     for field in dst_fields:
         fields_table.update_last_updated_time(field[0], sync_end_time)
     items_table.update_last_sync_time(dst_id, sync_end_time)
-    return True
+    return success
 
 #function for getting the list of items to be synced and passing them off to the sync function
 def sync_all(session):


### PR DESCRIPTION
Made linking a bit more robust by verifying that the tables exist before linking, if not then create the tables so that an exception doesn't occur. Also added a check to see if table was empty, which solves the problem if there weren't any fields in the Fields table and we tried to get the next field id. Also fixed the duplicate logging problem by removing any initial handlers from the root logger since we added a json handler instead.